### PR TITLE
feat: support include section, check_tolerance, and subscription supports file://

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,5 @@ See [example.dae](https://github.com/v2rayA/dae/blob/main/example.dae).
    But the problem is, after the Linux network stack, before entering the network card, we modify the source IP of this packet, causing the Linux network stack to only make a simple checksum, and the NIC also assumes that this packet is not sent from local, so no further checksum completing.
 1. MACv2 extension extraction.
 1. Log to userspace.
-1. Support include section.
 1. Subscription section supports key. And support to filter by subscription key.
 1. ...

--- a/README.md
+++ b/README.md
@@ -122,6 +122,5 @@ See [example.dae](https://github.com/v2rayA/dae/blob/main/example.dae).
 1. MACv2 extension extraction.
 1. Log to userspace.
 1. Support include section.
-1. Subscription section supports "file://"
-1. Subscription section supports key.
+1. Subscription section supports key. And support to filter by subscription key.
 1. ...

--- a/cmd/internal/subscription.go
+++ b/cmd/internal/subscription.go
@@ -89,7 +89,7 @@ func resolveFile(u *url.URL, configDir string) (b []byte, err error) {
 		return nil, fmt.Errorf("not support absolute path")
 	}
 	/// Relative location.
-	// Make sure path safety.
+	// Make sure path is secure.
 	path := filepath.Join(configDir, u.Host, u.Path)
 	if err = common.IsFileInSubDir(path, configDir); err != nil {
 		return nil, err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/v2rayA/dae/pkg/logger"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 )
 
@@ -55,7 +56,7 @@ func Run(log *logrus.Logger, param *config.Params) (err error) {
 	nodeList := make([]string, len(param.Node))
 	copy(nodeList, param.Node)
 	for _, sub := range param.Subscription {
-		nodes, err := internal.ResolveSubscription(log, sub)
+		nodes, err := internal.ResolveSubscription(log, filepath.Dir(cfgFile), sub)
 		if err != nil {
 			log.Warnf(`failed to resolve subscription "%v": %v`, sub, err)
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -21,7 +21,7 @@ var (
 				os.Exit(1)
 			}
 			// Read config from --config cfgFile.
-			_, err := readConfig(cfgFile)
+			_, _, err := readConfig(cfgFile)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/common/utils.go
+++ b/common/utils.go
@@ -309,7 +309,7 @@ func FuzzyDecode(to interface{}, val string) bool {
 	return true
 }
 
-func IsFileInSubDir(filePath string, dir string) (err error) {
+func EnsureFileInSubDir(filePath string, dir string) (err error) {
 	fileDir := filepath.Dir(filePath)
 	if len(dir) == 0 {
 		return fmt.Errorf("bad dir: %v", dir)
@@ -322,4 +322,20 @@ func IsFileInSubDir(filePath string, dir string) (err error) {
 		return fmt.Errorf("file is out of scope: %v", rel)
 	}
 	return nil
+}
+
+func MapKeys(m interface{}) (keys []string, err error) {
+	v := reflect.ValueOf(m)
+	if v.Kind() != reflect.Map {
+		return nil, fmt.Errorf("MapKeys requires map[string]*")
+	}
+	if v.Type().Key().Kind() != reflect.String {
+		return nil, fmt.Errorf("MapKeys requires map[string]*")
+	}
+	_keys := v.MapKeys()
+	keys = make([]string, 0, len(_keys))
+	for _, k := range _keys {
+		keys = append(keys, k.String())
+	}
+	return keys, nil
 }

--- a/common/utils.go
+++ b/common/utils.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -306,4 +307,19 @@ func FuzzyDecode(to interface{}, val string) bool {
 		return false
 	}
 	return true
+}
+
+func IsFileInSubDir(filePath string, dir string) (err error) {
+	fileDir := filepath.Dir(filePath)
+	if len(dir) == 0 {
+		return fmt.Errorf("bad dir: %v", dir)
+	}
+	rel, err := filepath.Rel(dir, fileDir)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("file is out of scope: %v", rel)
+	}
+	return nil
 }

--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -195,7 +195,10 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 
 func (a *AliveDialerSet) calcMinLatency() {
 	for _, d := range a.inorderedAliveDialerSet {
-		latency := a.dialerToLatency[d]
+		latency, ok := a.dialerToLatency[d]
+		if !ok {
+			continue
+		}
 		if latency < a.minLatency.latency {
 			a.minLatency.latency = latency
 			a.minLatency.dialer = d

--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -26,6 +26,7 @@ type AliveDialerSet struct {
 	dialerGroupName string
 	l4proto         consts.L4ProtoStr
 	ipversion       consts.IpVersionStr
+	tolerance       time.Duration
 
 	aliveChangeCallback func(alive bool)
 
@@ -43,6 +44,7 @@ func NewAliveDialerSet(
 	dialerGroupName string,
 	l4proto consts.L4ProtoStr,
 	ipversion consts.IpVersionStr,
+	tolerance time.Duration,
 	selectionPolicy consts.DialerSelectionPolicy,
 	dialers []*Dialer,
 	aliveChangeCallback func(alive bool),
@@ -53,6 +55,7 @@ func NewAliveDialerSet(
 		dialerGroupName:         dialerGroupName,
 		l4proto:                 l4proto,
 		ipversion:               ipversion,
+		tolerance:               tolerance,
 		aliveChangeCallback:     aliveChangeCallback,
 		dialerToIndex:           make(map[*Dialer]int),
 		dialerToLatency:         make(map[*Dialer]time.Duration),
@@ -146,14 +149,19 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 		bakOldBestDialer := a.minLatency.dialer
 		// Calc minLatency.
 		a.dialerToLatency[dialer] = latency
-		if alive && latency < a.minLatency.latency {
+		if alive && latency <= a.minLatency.latency-a.tolerance {
 			a.minLatency.latency = latency
 			a.minLatency.dialer = dialer
 		} else if a.minLatency.dialer == dialer {
-			a.minLatency.latency = time.Hour
-			a.minLatency.dialer = nil
-			a.calcMinLatency()
-			// Now `a.minLatency.dialer` will be nil if there is no alive dialer.
+			if latency > a.minLatency.latency {
+				// Latency increases.
+				a.minLatency.latency = time.Hour
+				a.minLatency.dialer = nil
+				a.calcMinLatency()
+				// Now `a.minLatency.dialer` will be nil if there is no alive dialer.
+			} else {
+				a.minLatency.latency = latency
+			}
 		}
 		currentAlive := a.minLatency.dialer != nil
 		// If best dialer changed.
@@ -169,7 +177,8 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 					string(a.selectionPolicy): a.minLatency.latency,
 					"group":                   a.dialerGroupName,
 					"network":                 string(a.l4proto) + string(a.ipversion),
-					"dialer":                  a.minLatency.dialer.Name(),
+					"new dialer":              a.minLatency.dialer.Name(),
+					"old dialer":              bakOldBestDialer.Name(),
 				}).Infof("Group %vselects dialer", re)
 			} else {
 				// Alive -> not alive
@@ -199,7 +208,7 @@ func (a *AliveDialerSet) calcMinLatency() {
 		if !ok {
 			continue
 		}
-		if latency < a.minLatency.latency {
+		if latency <= a.minLatency.latency-a.tolerance {
 			a.minLatency.latency = latency
 			a.minLatency.dialer = d
 		}

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -37,6 +37,7 @@ type GlobalOption struct {
 	TcpCheckOptionRaw TcpCheckOptionRaw // Lazy parse
 	UdpCheckOptionRaw UdpCheckOptionRaw // Lazy parse
 	CheckInterval     time.Duration
+	CheckTolerance    time.Duration
 }
 
 type InstanceOption struct {

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -39,10 +39,10 @@ type DialerGroup struct {
 func NewDialerGroup(option *dialer.GlobalOption, name string, dialers []*dialer.Dialer, p DialerSelectionPolicy, aliveChangeCallback func(alive bool, l4proto uint8, ipversion uint8)) *DialerGroup {
 	log := option.Log
 	var registeredAliveDialerSet bool
-	aliveTcp4DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_TCP, consts.IpVersionStr_4, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_TCP, 4) }, true)
-	aliveTcp6DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_TCP, consts.IpVersionStr_6, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_TCP, 6) }, true)
-	aliveUdp4DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_UDP, consts.IpVersionStr_4, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_UDP, 4) }, true)
-	aliveUdp6DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_UDP, consts.IpVersionStr_6, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_UDP, 6) }, true)
+	aliveTcp4DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_TCP, consts.IpVersionStr_4, option.CheckTolerance, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_TCP, 4) }, true)
+	aliveTcp6DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_TCP, consts.IpVersionStr_6, option.CheckTolerance, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_TCP, 6) }, true)
+	aliveUdp4DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_UDP, consts.IpVersionStr_4, option.CheckTolerance, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_UDP, 4) }, true)
+	aliveUdp6DialerSet := dialer.NewAliveDialerSet(log, name, consts.L4ProtoStr_UDP, consts.IpVersionStr_6, option.CheckTolerance, p.Policy, dialers, func(alive bool) { aliveChangeCallback(alive, unix.IPPROTO_UDP, 6) }, true)
 
 	switch p.Policy {
 	case consts.DialerSelectionPolicy_Random,

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ type Params struct {
 	Routing      Routing  `mapstructure:"routing" parser:"RoutingRuleAndParamParser"`
 }
 
-// New params from sections. This func assumes merging (section "include") and deduplication for sections has been executed.
+// New params from sections. This func assumes merging (section "include") and deduplication for section names has been executed.
 func New(sections []*config_parser.Section) (params *Params, err error) {
 	// Set up name to section for further use.
 	type Section struct {
@@ -96,8 +96,11 @@ func New(sections []*config_parser.Section) (params *Params, err error) {
 		section.Parsed = true
 	}
 
-	// Report unknown. Not "unused" because we assume deduplication has been executed before this func.
+	// Report unknown. Not "unused" because we assume section name deduplication has been executed before this func.
 	for name, section := range nameToSection {
+		if section.Val.Name == "include" {
+			continue
+		}
 		if !section.Parsed {
 			return nil, fmt.Errorf("unknown section: %v", name)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -14,14 +14,15 @@ import (
 )
 
 type Global struct {
-	TproxyPort    uint16            `mapstructure:"tproxy_port" default:"12345"`
-	LogLevel      string            `mapstructure:"log_level" default:"info"`
-	TcpCheckUrl   string            `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com"`
-	UdpCheckDns   string            `mapstructure:"udp_check_dns" default:"cloudflare-dns.com:53"`
-	CheckInterval time.Duration     `mapstructure:"check_interval" default:"30s"`
-	DnsUpstream   common.UrlOrEmpty `mapstructure:"dns_upstream" require:""`
-	LanInterface  []string          `mapstructure:"lan_interface"`
-	WanInterface  []string          `mapstructure:"wan_interface"`
+	TproxyPort     uint16            `mapstructure:"tproxy_port" default:"12345"`
+	LogLevel       string            `mapstructure:"log_level" default:"info"`
+	TcpCheckUrl    string            `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com"`
+	UdpCheckDns    string            `mapstructure:"udp_check_dns" default:"cloudflare-dns.com:53"`
+	CheckInterval  time.Duration     `mapstructure:"check_interval" default:"30s"`
+	CheckTolerance time.Duration     `mapstructure:"check_tolerance" default:"0"`
+	DnsUpstream    common.UrlOrEmpty `mapstructure:"dns_upstream" require:""`
+	LanInterface   []string          `mapstructure:"lan_interface"`
+	WanInterface   []string          `mapstructure:"wan_interface"`
 }
 
 type Group struct {

--- a/config/config_merger.go
+++ b/config/config_merger.go
@@ -1,0 +1,193 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) since 2023, mzz2017 <mzz@tuta.io>
+ */
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"github.com/v2rayA/dae/common"
+	"github.com/v2rayA/dae/pkg/config_parser"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	CircularIncludeError = fmt.Errorf("circular include is not allowed")
+)
+
+type Merger struct {
+	entry             string
+	entryDir          string
+	entryToSectionMap map[string]map[string][]*config_parser.Item
+}
+
+func NewMerger(entry string) *Merger {
+	return &Merger{
+		entry:             entry,
+		entryDir:          filepath.Dir(entry),
+		entryToSectionMap: map[string]map[string][]*config_parser.Item{},
+	}
+}
+
+func (m *Merger) Merge() (sections []*config_parser.Section, entries []string, err error) {
+	err = m.dfsMerge(m.entry, "")
+	if err != nil {
+		return nil, nil, err
+	}
+	entries, err = common.MapKeys(m.entryToSectionMap)
+	if err != nil {
+		return nil, nil, err
+	}
+	return m.convertMapToSections(m.entryToSectionMap[m.entry]), entries, nil
+}
+
+func (m *Merger) readEntry(entry string) (err error) {
+	// Check circular include.
+	_, exist := m.entryToSectionMap[entry]
+	if exist {
+		return CircularIncludeError
+	}
+
+	// Check filename
+	if !strings.HasSuffix(entry, ".dae") {
+		return fmt.Errorf("invalid config filename %v: must has suffix .dae", entry)
+	}
+	// Check file path security.
+	if err = common.EnsureFileInSubDir(entry, m.entryDir); err != nil {
+		return fmt.Errorf("failed in checking path of config file %v: %w", entry, err)
+	}
+	f, err := os.Open(entry)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %v: %w", entry, err)
+	}
+	// Check file access.
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("cannot include a directory: %v", entry)
+	}
+	if fi.Mode()&0037 > 0 {
+		return fmt.Errorf("permissions %04o for '%v' are too open; requires the file is NOT writable by the same group and NOT accessible by others; suggest 0640 or 0600", fi.Mode()&0777, entry)
+	}
+	// Read and parse.
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	entrySections, err := config_parser.Parse(string(b))
+	if err != nil {
+		return fmt.Errorf("failed to parse config file %v:\n%w", entry, err)
+	}
+	m.entryToSectionMap[entry] = m.convertSectionsToMap(entrySections)
+	return nil
+}
+
+func unsqueezeEntries(patternEntries []string) (unsqueezed []string, err error) {
+	unsqueezed = make([]string, 0, len(patternEntries))
+	for _, pattern := range patternEntries {
+		files, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			// We only support .dae
+			if !strings.HasSuffix(file, ".dae") {
+				continue
+			}
+			fi, err := os.Stat(file)
+			if err != nil {
+				return nil, err
+			}
+			if fi.IsDir() {
+				continue
+			}
+			unsqueezed = append(unsqueezed, file)
+		}
+	}
+	if len(unsqueezed) == 0 {
+		unsqueezed = nil
+	}
+	return unsqueezed, nil
+}
+
+func (m *Merger) dfsMerge(entry string, fatherEntry string) (err error) {
+	// Read entry and check circular include.
+	if err = m.readEntry(entry); err != nil {
+		if errors.Is(err, CircularIncludeError) {
+			return fmt.Errorf("%w: %v -> %v -> ... -> %v", err, fatherEntry, entry, fatherEntry)
+		}
+		return err
+	}
+	sectionMap := m.entryToSectionMap[entry]
+	// Extract childEntries.
+	includes := sectionMap["include"]
+	var patterEntries = make([]string, 0, len(includes))
+	for _, include := range includes {
+		switch v := include.Value.(type) {
+		case *config_parser.Param:
+			nextEntry := v.String(true)
+			patterEntries = append(patterEntries, filepath.Join(m.entryDir, nextEntry))
+		default:
+			return fmt.Errorf("unsupported include grammar in %v: %v", entry, include.String())
+		}
+	}
+	// DFS and merge children recursively.
+	childEntries, err := unsqueezeEntries(patterEntries)
+	if err != nil {
+		return err
+	}
+	for _, nextEntry := range childEntries {
+		if err = m.dfsMerge(nextEntry, entry); err != nil {
+			return err
+		}
+	}
+	/// Merge into father. Do not need to retrieve sectionMap again because go map is a reference.
+	if fatherEntry == "" {
+		// We are already on the top.
+		return nil
+	}
+	fatherSectionMap := m.entryToSectionMap[fatherEntry]
+	for sec := range sectionMap {
+		items := m.mergeItems(fatherSectionMap[sec], sectionMap[sec])
+		fatherSectionMap[sec] = items
+	}
+	return nil
+}
+
+func (m *Merger) convertSectionsToMap(sections []*config_parser.Section) (sectionMap map[string][]*config_parser.Item) {
+	sectionMap = make(map[string][]*config_parser.Item)
+	for _, sec := range sections {
+		items, ok := sectionMap[sec.Name]
+		if ok {
+			sectionMap[sec.Name] = m.mergeItems(items, sec.Items)
+		} else {
+			sectionMap[sec.Name] = sec.Items
+		}
+	}
+	return sectionMap
+}
+
+func (m *Merger) convertMapToSections(sectionMap map[string][]*config_parser.Item) (sections []*config_parser.Section) {
+	sections = make([]*config_parser.Section, 0, len(sectionMap))
+	for name, items := range sectionMap {
+		sections = append(sections, &config_parser.Section{
+			Name:  name,
+			Items: items,
+		})
+	}
+	return sections
+}
+
+func (m *Merger) mergeItems(to, from []*config_parser.Item) (items []*config_parser.Item) {
+	items = make([]*config_parser.Item, len(to)+len(from))
+	copy(items, to)
+	copy(items[len(to):], from)
+	return items
+}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -196,6 +196,7 @@ func NewControlPlane(
 		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: global.TcpCheckUrl},
 		UdpCheckOptionRaw: dialer.UdpCheckOptionRaw{Raw: global.UdpCheckDns},
 		CheckInterval:     global.CheckInterval,
+		CheckTolerance:    global.CheckTolerance,
 	}
 	outbounds := []*outbound.DialerGroup{
 		outbound.NewDialerGroup(option, consts.OutboundDirect.String(),

--- a/example.dae
+++ b/example.dae
@@ -10,6 +10,8 @@ global {
     tcp_check_url: 'http://cp.cloudflare.com'
     udp_check_dns: 'dns.google:53'
     check_interval: 30s
+    # Group will switch node only when new_latency <= old_latency - tolerance
+    check_tolerance: 50ms
 
     # Value can be scheme://host:port or empty string ''.
     # The scheme can be tcp/udp/tcp+udp. Empty string '' indicates as-is.

--- a/example.dae
+++ b/example.dae
@@ -76,7 +76,7 @@ routing {
     ip(geoip:private, 224.0.0.0/3, 'ff00::/8') -> direct # Put it first unless you know what you're doing.
     # Write your rules below.
 
-    # dae arms DNS rush-answer filter so we can use 8.8.8.8 regardless of DNS pollution.
+    # dae arms DNS rush-answer filter so we can use dns.google regardless of DNS pollution.
     domain(full:dns.google) && port(53) -> direct
 
     pname(firefox) && domain(ip.sb) -> direct


### PR DESCRIPTION
Example:
```
include {
    # Pattern will be resolved as files with suffix .dae
    conf.d/*
    test.dae
}

subscription {
    'file://sub.d/sub1'
}
```
Content of `sub.d/sub1` is exact the content `GET` from subscription link.