### PR TITLE
doc: adopt getting-started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ As a successor of [v2rayA](https://github.com/v2rayA/v2rayA), dae abandoned v2ra
 1. Support to automatically switch nodes according to policy. That is to say, support to automatically test independent TCP/UDP/IPv4/IPv6 latencies, and then use the best nodes for corresponding traffic according to user-defined policy.
 1. Support full-cone NAT for shadowsocks, vmess, socks5 and trojan(-go).
 
-## Linux Kernel Requirement
+## Prerequisites
 
 ### Kernel Version
 
@@ -79,61 +79,19 @@ EOF
 sudo sysctl --system
 ```
 
-## Usage
+## Getting Started
 
-### Build
-
-**Make Dependencies**
-
-```shell
-clang >= 10
-llvm >= 10
-golang >= 1.18
-make
-```
-
-**Build**
-
-```shell
-git clone https://github.com/v2rayA/dae.git
-cd dae
-git submodule update --init
-# Minimal dependency build:
-make GOFLAGS="-buildvcs=false" CC=clang
-# Or normal build:
-# make
-```
-
-### Run
-
-**Runtime Dependencies**
-
-Download [geoip.dat](https://github.com/v2ray/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest) to `/usr/local/share/dae/`.
-
-```
-mkdir -p /usr/local/share/dae/
-pushd /usr/local/share/dae/
-curl -L -o geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-curl -L -o geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
-popd
-```
-
-**Run**
-
-```shell
-./dae run -c example.dae
-```
-
-See [example.dae](https://github.com/v2rayA/dae/blob/main/example.dae).
+Please refer to [Quick Start Guide](./docs/getting-started/README.md) to start using `Dae` right away!
 
 ## TODO
 
-1. Check dns upstream and source loop (whether upstream is also a client of us) and remind the user to add sip rule.
-1. WAN L4Checksum problem.
-   If the NIC checksumming offload is enabled, the Linux network stack will make a simple checksum a packet when it is sent out from local. When NIC discovers that the source IP of the packet is the local IP of the NIC, it will checksum it complete this checksum.
-   But the problem is, after the Linux network stack, before entering the network card, we modify the source IP of this packet, causing the Linux network stack to only make a simple checksum, and the NIC also assumes that this packet is not sent from local, so no further checksum completing.
-1. MACv2 extension extraction.
-1. Log to userspace.
-1. Protocol-oriented node features detecting (or filter), such as full-cone (especially VMess and VLESS).
-1. DNS traffic split.
-1. ...
+[ ] - Check dns upstream and source loop (whether upstream is also a client of us) and remind the user to add sip rule.
+[ ] - WAN L4Checksum problem.
+[ ] - If the NIC checksumming offload is enabled, the Linux network stack will make a simple checksum a packet when it is sent out from local. When NIC discovers that the source IP of the packet is the local IP of the NIC, it will checksum it complete this checksum.
+[ ] - But the problem is, after the Linux network stack, before entering the network card, we modify the source IP of this packet, causing the Linux network stack to only make a simple checksum, and the NIC also assumes that this packet is not sent from local, so no further checksum completing.
+[ ] - MACv2 extension extraction.
+[ ] - Log to userspace.
+[ ] - Protocol-oriented node features detecting (or filter), such as full-cone (especially VMess and VLESS).
+[ ] - DNS traffic split.
+[ ] - Add quick-start guide
+[ ] - ...

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Please refer to [Quick Start Guide](./docs/getting-started/README.md) to start u
 
 ## TODO
 
-[ ] - Check dns upstream and source loop (whether upstream is also a client of us) and remind the user to add sip rule.
-[ ] - WAN L4Checksum problem.
-[ ] - If the NIC checksumming offload is enabled, the Linux network stack will make a simple checksum a packet when it is sent out from local. When NIC discovers that the source IP of the packet is the local IP of the NIC, it will checksum it complete this checksum.
-[ ] - But the problem is, after the Linux network stack, before entering the network card, we modify the source IP of this packet, causing the Linux network stack to only make a simple checksum, and the NIC also assumes that this packet is not sent from local, so no further checksum completing.
-[ ] - MACv2 extension extraction.
-[ ] - Log to userspace.
-[ ] - Protocol-oriented node features detecting (or filter), such as full-cone (especially VMess and VLESS).
-[ ] - DNS traffic split.
-[ ] - Add quick-start guide
-[ ] - ...
+- [ ] Check dns upstream and source loop (whether upstream is also a client of us) and remind the user to add sip rule.
+- [ ] WAN L4Checksum problem.
+- [ ] If the NIC checksumming offload is enabled, the Linux network stack will make a simple checksum a packet when it is sent out from local. When NIC discovers that the source IP of the packet is the local IP of the NIC, it will checksum it complete this checksum.
+- [ ] But the problem is, after the Linux network stack, before entering the network card, we modify the source IP of this packet, causing the Linux network stack to only make a simple checksum, and the NIC also assumes that this packet is not sent from local, so no further checksum completing.
+- [ ] MACv2 extension extraction.
+- [ ] Log to userspace.
+- [ ] Protocol-oriented node features detecting (or filter), such as full-cone (especially VMess and VLESS).
+- [ ] DNS traffic split.
+- [ ] Add quick-start guide
+- [ ] ...

--- a/README.md
+++ b/README.md
@@ -79,6 +79,53 @@ EOF
 sudo sysctl --system
 ```
 
+## Usage
+
+### Build
+
+**Make Dependencies**
+
+```shell
+clang >= 10
+llvm >= 10
+golang >= 1.18
+make
+```
+
+**Build**
+
+```shell
+git clone https://github.com/v2rayA/dae.git
+cd dae
+git submodule update --init
+# Minimal dependency build:
+make GOFLAGS="-buildvcs=false" CC=clang
+# Or normal build:
+# make
+```
+
+### Run
+
+**Runtime Dependencies**
+
+Download [geoip.dat](https://github.com/v2ray/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest) to `/usr/local/share/dae/`.
+
+```
+mkdir -p /usr/local/share/dae/
+pushd /usr/local/share/dae/
+curl -L -o geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
+curl -L -o geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+popd
+```
+
+**Run**
+
+```shell
+./dae run -c example.dae
+```
+
+See [example.dae](https://github.com/v2rayA/dae/blob/main/example.dae).
+
 ## Getting Started
 
 Please refer to [Quick Start Guide](./docs/getting-started/README.md) to start using `Dae` right away!

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,66 @@
+# Quick Start Guide
+
+## Linux Kernel Requirement
+
+### Kernel Version
+
+Use `uname -r` to check the kernel version on your machine.
+
+> **Notes**
+> If you find your kernel version is `< 5.8`, follow the guide [HERE](./kernel-upgrade.md) to upgrade the kernel to the minimum required version.
+
+**Bind to LAN: >= 5.8**
+
+You need bind dae to LAN interface, if you want to provide network service for LAN as an intermediate device.
+
+This feature requires the kernel version of machine on which dae install >= 5.8.
+
+Note that if you bind dae to LAN only, dae only provide network service for traffic from LAN, and not impact local programs.
+
+**Bind to WAN: >= 5.8**
+
+You need bind dae to WAN interface, if you want dae to provide network service for local programs.
+
+This feature requires kernel version of the machine >= 5.8.
+
+Note that if you bind dae to WAN only, dae only provide network service for local programs and not impact traffic coming in from other interfaces.
+
+### Kernel Configuration Item
+
+Usually, mainstream desktop distributions have these items turned on. But in order to reduce kernel size, some items are turned off by default on embedded device distributions like OpenWRT, Armbian, etc.
+
+Use following command to show kernel configuration items on your machine.
+
+```shell
+zcat /proc/config.gz || cat /boot/{config,config-$(uname -r)}
+```
+
+**Bind to LAN**
+
+```
+CONFIG_DEBUG_INFO_BTF
+```
+
+**Bind to WAN**
+
+```
+CONFIG_DEBUG_INFO_BTF
+```
+
+Check them using command like:
+
+```shell
+(zcat /proc/config.gz || cat /boot/{config,config-$(uname -r)}) | grep 'CONFIG_DEBUG_INFO_BTF='
+```
+
+### Enable IP Forwarding
+
+By default, any latest Linux distributions will have IP Forwarding `disabled`. In the case where we need to up a Linux router/gateway or a VPN server or simply a plain dial-in server, then we must need to enable forwarding. Do the followings to have `ip-forwarding` feature enabled:
+
+```shell
+sudo tee /etc/sysctl.d/dae.conf<<EOF
+net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1
+EOF
+sudo sysctl --system
+```

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -9,58 +9,49 @@ Use `uname -r` to check the kernel version on your machine.
 > **Notes**
 > If you find your kernel version is `< 5.8`, follow the guide [HERE](./kernel-upgrade.md) to upgrade the kernel to the minimum required version.
 
-**Bind to LAN: >= 5.8**
+## Usage
 
-You need bind dae to LAN interface, if you want to provide network service for LAN as an intermediate device.
+### Build
 
-This feature requires the kernel version of machine on which dae install >= 5.8.
-
-Note that if you bind dae to LAN only, dae only provide network service for traffic from LAN, and not impact local programs.
-
-**Bind to WAN: >= 5.8**
-
-You need bind dae to WAN interface, if you want dae to provide network service for local programs.
-
-This feature requires kernel version of the machine >= 5.8.
-
-Note that if you bind dae to WAN only, dae only provide network service for local programs and not impact traffic coming in from other interfaces.
-
-### Kernel Configuration Item
-
-Usually, mainstream desktop distributions have these items turned on. But in order to reduce kernel size, some items are turned off by default on embedded device distributions like OpenWRT, Armbian, etc.
-
-Use following command to show kernel configuration items on your machine.
+**Make Dependencies**
 
 ```shell
-zcat /proc/config.gz || cat /boot/{config,config-$(uname -r)}
+clang >= 10
+llvm >= 10
+golang >= 1.18
+make
 ```
 
-**Bind to LAN**
-
-```
-CONFIG_DEBUG_INFO_BTF
-```
-
-**Bind to WAN**
-
-```
-CONFIG_DEBUG_INFO_BTF
-```
-
-Check them using command like:
+**Build**
 
 ```shell
-(zcat /proc/config.gz || cat /boot/{config,config-$(uname -r)}) | grep 'CONFIG_DEBUG_INFO_BTF='
+git clone https://github.com/v2rayA/dae.git
+cd dae
+git submodule update --init
+# Minimal dependency build:
+make GOFLAGS="-buildvcs=false" CC=clang
+# Or normal build:
+# make
 ```
 
-### Enable IP Forwarding
+### Run
 
-By default, any latest Linux distributions will have IP Forwarding `disabled`. In the case where we need to up a Linux router/gateway or a VPN server or simply a plain dial-in server, then we must need to enable forwarding. Do the followings to have `ip-forwarding` feature enabled:
+**Runtime Dependencies**
+
+Download [geoip.dat](https://github.com/v2ray/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest) to `/usr/local/share/dae/`.
+
+```
+mkdir -p /usr/local/share/dae/
+pushd /usr/local/share/dae/
+curl -L -o geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
+curl -L -o geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+popd
+```
+
+**Run**
 
 ```shell
-sudo tee /etc/sysctl.d/dae.conf<<EOF
-net.ipv4.ip_forward = 1
-net.ipv6.conf.all.forwarding = 1
-EOF
-sudo sysctl --system
+./dae run -c example.dae
 ```
+
+See [example.dae](https://github.com/v2rayA/dae/blob/main/example.dae).

--- a/docs/getting-started/kernel-upgrade.md
+++ b/docs/getting-started/kernel-upgrade.md
@@ -1,0 +1,58 @@
+# Kernel Upgrade Guide
+
+A `kernel` is the core of any operating system. Before you start calling Linux an operating system, you need to know the basic concept and Linux’s birth history. **_Linux is not an operating system; mainly, Linux is a kernel_**.
+
+## Upgrade Guide
+
+### Disclaimer
+
+Upgrading the Linux kernel is not easy; you must do this only if you find security errors or hardware interaction issues. If your system crashes, you might have to recover the whole system. Mostly, Linux distributions come with the most upgraded kernel. Upgrading the Linux kernel doesn’t delete or remove the previous kernel; it is kept inside the system.
+
+> **Notes**
+> You should not upgrade your kernel manually unless you want some specific driver support. You can roll back to the older kernel from the recovery menu of your Linux system. However, you may need to upgrade the kernel for hardware issues or security issues.
+
+### Preparation
+
+Before you start upgrading your Linux kernel, you must know the Kernel’s `current version` running inside your host machine. You may do so by `uname -r`. In case of `eBPF`, the minimum required version is `>= 5.8`
+
+Various Linux distributions have different methods to upgrade the Linux kernel. This guide convers ways to upgrade the kernel to a desired version for most `Debian-based Linux`, `RedHar, Fedora based Linux`, and `Arch-based Linux` distributions.
+
+> **Notes**
+> Since `Dae` is builts with `eBPF`, your host must meet the minimum Kernel version, `>= 5.8` for dae to properly running.
+
+### Upgrade Kernel on Debian-based Linux
+
+```bash
+sudo apt search linux-image
+
+```
+
+### Upgrade kernel on RedHat and Fedora Linux
+
+Fedora, RedHat, and RedHat-based Linux distribution users can upgrade their Linux kernel manually by downloading the kernel from the repository.
+
+Fedora and RedHat Linux users can install a specific version of Kernel on their system. You can run the following command-line on your Linux terminal to install any specific version kernel on your Linux system. After the installation is done, reboot your system to get the desired kernel on your Linux system.
+
+```bash
+sudo yum update kernel
+sudo yum install kernel-{version}
+sudo reboot
+uname -r
+```
+
+### Upgrade kernel on Arch-based Linux
+
+Arch and Arch-based Linux distributions have a `dynamic` variety of Linux kernel. Arch Linux updates its security patch regularly; that’s why you will see notable kernel and patch updates are available on Arch Linux. Here, I will describe two methods to upgrade the kernel on Arch Linux.
+
+Manjaro and other Arch Linux distributions often offer kernel updates and upgrades via the conventional update manager. When you run the system updater on the Linux system, it checks for the latest kernels. You can use the following `pacman` command to check for the latest kernel on Arch Linux distributions.
+
+```bash
+sudo pacman -Syu
+```
+
+If it finds a new kernel, it will notify you to download and install it. You can choose whether you want to get the latest kernel or not. Once you agree to install, reboot your system after the installation is finished. Then, you can check the kernel version to ensure whether the kernel is upgraded or not.
+
+```bash
+sudo reboot
+uname -r
+```

--- a/docs/getting-started/kernel-upgrade.md
+++ b/docs/getting-started/kernel-upgrade.md
@@ -2,7 +2,7 @@
 
 A `kernel` is the core of any operating system. Before you start calling Linux an operating system, you need to know the basic concept and Linux’s birth history. **_Linux is not an operating system; mainly, Linux is a kernel_**.
 
-## Upgrade Guide
+## How To Upgrade Linux Kernel On Various Distributions
 
 ### Disclaimer
 
@@ -22,9 +22,26 @@ Various Linux distributions have different methods to upgrade the Linux kernel. 
 
 ### Upgrade Kernel on Debian-based Linux
 
-```bash
-sudo apt search linux-image
+Debian-based Linux distribution users can upgrade their Linux kernel upgrading the `linux-image-generic` to a desired version by making use of the [mainline](https://github.com/pimlie/ubuntu-mainline-kernel.sh) tool. It will update both `linux-image-generic` and `linux-headers-generic`.
 
+```bash
+sudo apt-add-repository -y ppa:cappelikan/ppa
+sudo apt update
+sudo apt install wget mainline
+wget https://raw.githubusercontent.com/pimlie/ubuntu-mainline-kernel.sh/master/ubuntu-mainline-kernel.sh
+chmod +x ubuntu-mainline-kernel.sh
+sudo install ubuntu-mainline-kernel.sh /usr/local/bin/
+
+# list available kernel patches
+ubuntu-mainline-kernel.sh -l
+ubuntu-mainline-kernel.sh -i <DESIRED VERSION>
+```
+
+Reboot to take effect
+
+```bash
+reboot
+uname -r
 ```
 
 ### Upgrade kernel on RedHat and Fedora Linux
@@ -36,6 +53,11 @@ Fedora and RedHat Linux users can install a specific version of Kernel on their 
 ```bash
 sudo yum update kernel
 sudo yum install kernel-{version}
+```
+
+Reboot to take effect
+
+```bash
 sudo reboot
 uname -r
 ```

--- a/docs/getting-started/kernel-upgrade.md
+++ b/docs/getting-started/kernel-upgrade.md
@@ -8,7 +8,7 @@ A `kernel` is the core of any operating system. Before you start calling Linux a
 
 Upgrading the Linux kernel is not easy; you must do this only if you find security errors or hardware interaction issues. If your system crashes, you might have to recover the whole system. Mostly, Linux distributions come with the most upgraded kernel. Upgrading the Linux kernel doesn’t delete or remove the previous kernel; it is kept inside the system.
 
-> **Notes**
+> **Note**
 > You should not upgrade your kernel manually unless you want some specific driver support. You can roll back to the older kernel from the recovery menu of your Linux system. However, you may need to upgrade the kernel for hardware issues or security issues.
 
 ### Preparation
@@ -17,7 +17,7 @@ Before you start upgrading your Linux kernel, you must know the Kernel’s `curr
 
 Various Linux distributions have different methods to upgrade the Linux kernel. This guide convers ways to upgrade the kernel to a desired version for most `Debian-based Linux`, `RedHar, Fedora based Linux`, and `Arch-based Linux` distributions.
 
-> **Notes**
+> **Note**
 > Since `Dae` is builts with `eBPF`, your host must meet the minimum Kernel version, `>= 5.8` for dae to properly running.
 
 ### Upgrade Kernel on Debian-based Linux


### PR DESCRIPTION
## Summary

Move the `Usage` section to the `Getting-started` section for a cleaner look.

## Proposed file structure

```
./docs
├── getting-started
│   ├── kernel-upgrade.md
│   └── README.md
└── ...

N directories, N files
```

## Preview

https://github.com/yqlbu/dae/tree/docs

## Changelogs

- [x] Move the `Getting-started` section under `./docs`.
- [x] Add support for the `Kernel` upgrade guide.