### PR TITLE
feat: support to mark direct traffic

### DIFF
--- a/common/consts/ebpf.go
+++ b/common/consts/ebpf.go
@@ -15,7 +15,7 @@ const (
 	AppName    = "dae"
 	BpfPinRoot = "/sys/fs/bpf"
 
-	AddrHdrSize = 20
+	AddrHdrSize = 24
 
 	TaskCommLen = 16
 )

--- a/common/consts/routing.go
+++ b/common/consts/routing.go
@@ -10,8 +10,8 @@ type RoutingDomainKey string
 const (
 	RoutingDomainKey_Full    RoutingDomainKey = "full"
 	RoutingDomainKey_Keyword RoutingDomainKey = "keyword"
-	RoutingDomainKey_Suffix RoutingDomainKey = "suffix"
-	RoutingDomainKey_Regex  RoutingDomainKey = "regex"
+	RoutingDomainKey_Suffix  RoutingDomainKey = "suffix"
+	RoutingDomainKey_Regex   RoutingDomainKey = "regex"
 
 	Function_Domain      = "domain"
 	Function_Ip          = "ip"
@@ -24,4 +24,6 @@ const (
 	Function_ProcessName = "pname"
 
 	Declaration_Fallback = "fallback"
+
+	OutboundParam_Mark = "mark"
 )

--- a/common/netutils/dns.go
+++ b/common/netutils/dns.go
@@ -114,6 +114,7 @@ func ResolveNetip(ctx context.Context, d netproxy.Dialer, dns netip.AddrPort, ho
 		return nil, err
 	}
 	if tcp {
+		// Put DNS request length
 		buf := pool.Get(2 + len(b))
 		defer pool.Put(buf)
 		binary.BigEndian.PutUint16(buf, uint16(len(b)))
@@ -160,6 +161,7 @@ func ResolveNetip(ctx context.Context, d netproxy.Dialer, dns netip.AddrPort, ho
 		buf := pool.Get(512)
 		defer pool.Put(buf)
 		if tcp {
+			// Read DNS response length
 			_, err := io.ReadFull(c, buf[:2])
 			if err != nil {
 				ch <- err

--- a/common/utils.go
+++ b/common/utils.go
@@ -283,9 +283,9 @@ func FuzzyDecode(to interface{}, val string) bool {
 		v.SetUint(i)
 	case reflect.Bool:
 		switch strings.ToLower(val) {
-		case "true", "1", "y", "yes":
+		case "true", "t", "1", "y", "yes", "on":
 			v.SetBool(true)
-		case "false", "0", "n", "no":
+		case "false", "f", "0", "n", "no", "off":
 			v.SetBool(false)
 		default:
 			return false

--- a/component/outbound/dialer/block.go
+++ b/component/outbound/dialer/block.go
@@ -6,12 +6,28 @@
 package dialer
 
 import (
+	"fmt"
 	"github.com/mzz2017/softwind/netproxy"
 	"net"
 )
 
 type blockDialer struct {
 	DialCallback func()
+}
+
+func (d *blockDialer) Dial(network, addr string) (c netproxy.Conn, err error) {
+	magicNetwork, err := netproxy.ParseMagicNetwork(network)
+	if err != nil {
+		return nil, err
+	}
+	switch magicNetwork.Network {
+	case "tcp":
+		return d.DialTcp(addr)
+	case "udp":
+		return d.DialUdp(addr)
+	default:
+		return nil, fmt.Errorf("%w: %v", netproxy.UnsupportedTunnelTypeError, network)
+	}
 }
 
 func (d *blockDialer) DialTcp(addr string) (c netproxy.Conn, err error) {

--- a/component/outbound/transport/simpleobfs/simpleobfs.go
+++ b/component/outbound/transport/simpleobfs/simpleobfs.go
@@ -56,6 +56,22 @@ func NewSimpleObfs(s string, d netproxy.Dialer) (*SimpleObfs, error) {
 	return t, nil
 }
 
+
+func (s *SimpleObfs) Dial(network, addr string) (c netproxy.Conn, err error) {
+	magicNetwork, err := netproxy.ParseMagicNetwork(network)
+	if err != nil {
+		return nil, err
+	}
+	switch magicNetwork.Network {
+	case "tcp":
+		return s.DialTcp(addr)
+	case "udp":
+		return s.DialUdp(addr)
+	default:
+		return nil, fmt.Errorf("%w: %v", netproxy.UnsupportedTunnelTypeError, network)
+	}
+}
+
 func (s *SimpleObfs) DialUdp(addr string) (conn netproxy.PacketConn, err error) {
 	return nil, fmt.Errorf("%w: simpleobfs+udp", netproxy.UnsupportedTunnelTypeError)
 }

--- a/component/outbound/transport/tls/tls.go
+++ b/component/outbound/transport/tls/tls.go
@@ -47,9 +47,25 @@ func NewTls(s string, d netproxy.Dialer) (*Tls, error) {
 	return t, nil
 }
 
+func (s *Tls) Dial(network, addr string) (c netproxy.Conn, err error) {
+	magicNetwork, err := netproxy.ParseMagicNetwork(network)
+	if err != nil {
+		return nil, err
+	}
+	switch magicNetwork.Network {
+	case "tcp":
+		return s.DialTcp(addr)
+	case "udp":
+		return s.DialUdp(addr)
+	default:
+		return nil, fmt.Errorf("%w: %v", netproxy.UnsupportedTunnelTypeError, network)
+	}
+}
+
 func (s *Tls) DialUdp(addr string) (conn netproxy.PacketConn, err error) {
 	return nil, fmt.Errorf("%w: tls+udp", netproxy.UnsupportedTunnelTypeError)
 }
+
 func (s *Tls) DialTcp(addr string) (conn netproxy.Conn, err error) {
 	rc, err := s.dialer.DialTcp(addr)
 	if err != nil {

--- a/component/outbound/transport/ws/ws.go
+++ b/component/outbound/transport/ws/ws.go
@@ -67,6 +67,21 @@ func NewWs(s string, d netproxy.Dialer) (*Ws, error) {
 	return t, nil
 }
 
+func (s *Ws) Dial(network, addr string) (c netproxy.Conn, err error) {
+	magicNetwork, err := netproxy.ParseMagicNetwork(network)
+	if err != nil {
+		return nil, err
+	}
+	switch magicNetwork.Network {
+	case "tcp":
+		return s.DialTcp(addr)
+	case "udp":
+		return s.DialUdp(addr)
+	default:
+		return nil, fmt.Errorf("%w: %v", netproxy.UnsupportedTunnelTypeError, network)
+	}
+}
+
 func (s *Ws) DialUdp(addr string) (netproxy.PacketConn, error) {
 	return nil, fmt.Errorf("%w: ws+udp", netproxy.UnsupportedTunnelTypeError)
 }

--- a/component/routing/optimizer.go
+++ b/component/routing/optimizer.go
@@ -81,7 +81,7 @@ func (o *MergeAndSortRulesOptimizer) Optimize(rules []*config_parser.RoutingRule
 		if len(mergingRule.AndFunctions) == 1 &&
 			len(rules[i].AndFunctions) == 1 &&
 			mergingRule.AndFunctions[0].Name == rules[i].AndFunctions[0].Name &&
-			rules[i].Outbound == mergingRule.Outbound {
+			rules[i].Outbound.String(true) == mergingRule.Outbound.String(true) {
 			mergingRule.AndFunctions[0].Params = append(mergingRule.AndFunctions[0].Params, rules[i].AndFunctions[0].Params...)
 		} else {
 			newRules = append(newRules, mergingRule)

--- a/config/config.go
+++ b/config/config.go
@@ -42,8 +42,8 @@ type GroupParam struct {
 
 type Routing struct {
 	Rules    []*config_parser.RoutingRule `mapstructure:"_"`
-	Fallback string                       `mapstructure:"fallback"`
-	Final    string                       `mapstructure:"final"`
+	Fallback interface{}                  `mapstructure:"fallback"`
+	Final    interface{}                  `mapstructure:"final"`
 }
 
 type Params struct {

--- a/config/patch.go
+++ b/config/patch.go
@@ -5,7 +5,10 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/sirupsen/logrus"
+)
 
 type patch func(params *Params) error
 
@@ -15,11 +18,12 @@ var patches = []patch{
 
 func patchRoutingFallback(params *Params) error {
 	// We renamed final as fallback. So we apply this patch for compatibility with older users.
-	if params.Routing.Fallback == "" && params.Routing.Final != "" {
+	if params.Routing.Fallback == nil && params.Routing.Final != nil {
 		params.Routing.Fallback = params.Routing.Final
+		logrus.Warnln("Name 'final' in section routing was deprecated and will be removed in the future; please rename it as 'fallback'")
 	}
 	// Fallback is required.
-	if params.Routing.Fallback == "" {
+	if params.Routing.Fallback == nil {
 		return fmt.Errorf("fallback is required in routing")
 	}
 	return nil

--- a/control/tproxy_utils.go
+++ b/control/tproxy_utils.go
@@ -67,7 +67,7 @@ func checkIpforward(ifname string, ipversion consts.IpVersionStr) error {
 	if bytes.Equal(bytes.TrimSpace(b), []byte("1")) {
 		return nil
 	}
-	return fmt.Errorf("ipforward on %v is off: %v", ifname, path)
+	return fmt.Errorf("ipforward on %v is off: %v; see https://github.com/v2rayA/dae#enable-ip-forwarding", ifname, path)
 }
 
 func CheckIpforward(ifname string) error {

--- a/control/utils.go
+++ b/control/utils.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/mzz2017/softwind/netproxy"
 	"github.com/v2rayA/dae/common/consts"
 	internal "github.com/v2rayA/dae/pkg/ebpf_internal"
 	"golang.org/x/sys/unix"
@@ -17,7 +18,7 @@ import (
 	"syscall"
 )
 
-func (c *ControlPlaneCore) RetrieveOutboundIndex(src, dst netip.AddrPort, l4proto uint8) (outboundIndex consts.OutboundIndex, err error) {
+func (c *ControlPlaneCore) RetrieveRoutingResult(src, dst netip.AddrPort, l4proto uint8) (result *bpfRoutingResult, err error) {
 	srcIp6 := src.Addr().As16()
 	dstIp6 := dst.Addr().As16()
 
@@ -29,14 +30,11 @@ func (c *ControlPlaneCore) RetrieveOutboundIndex(src, dst netip.AddrPort, l4prot
 		L4proto: l4proto,
 	}
 
-	var _outboundIndex uint32
-	if err := c.bpf.RoutingTuplesMap.Lookup(tuples, &_outboundIndex); err != nil {
-		return 0, fmt.Errorf("reading map: key [%v, %v, %v]: %w", src.String(), l4proto, dst.String(), err)
+	var routingResult bpfRoutingResult
+	if err := c.bpf.RoutingTuplesMap.Lookup(tuples, &routingResult); err != nil {
+		return nil, fmt.Errorf("reading map: key [%v, %v, %v]: %w", src.String(), l4proto, dst.String(), err)
 	}
-	if _outboundIndex > uint32(consts.OutboundMax) {
-		return 0, fmt.Errorf("bad outbound index")
-	}
-	return consts.OutboundIndex(_outboundIndex), nil
+	return &routingResult, nil
 }
 
 func RetrieveOriginalDest(oob []byte) netip.AddrPort {
@@ -78,4 +76,15 @@ func CheckIpforward(ifname string) error {
 		return err
 	}
 	return nil
+}
+
+func GetNetwork(network string, mark uint32) string {
+	if mark == 0 {
+		return network
+	} else {
+		return netproxy.MagicNetwork{
+			Network: network,
+			Mark:    mark,
+		}.Encode()
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230217170818-542cba31602f
+	github.com/mzz2017/softwind v0.0.0-20230220064728-6940dc11777f
 	github.com/safchain/ethtool v0.0.0-20230116090318-67cc41908669
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/v2rayA/ahocorasick-domain v0.0.0-20230218160829-122a074c48c8
-	github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230201041341-1758ee5161c1
+	github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230219173344-413f12027632
 	github.com/vishvananda/netlink v1.1.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/crypto v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B90M=
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
-github.com/mzz2017/softwind v0.0.0-20230217170818-542cba31602f h1:zxc1LkGfczEwEdnOlaGbIhyVsoL9dWHEL2WQ4pPgC0c=
-github.com/mzz2017/softwind v0.0.0-20230217170818-542cba31602f/go.mod h1:V8GFOtdpTgzCJtCVXRqjmdDsY+PIhCCx4JpD0zq8Z7I=
+github.com/mzz2017/softwind v0.0.0-20230220064728-6940dc11777f h1:Lmwy7FFI0PrWw0TgoQYtDiZBlCd/VZ1hBlySauTVWj4=
+github.com/mzz2017/softwind v0.0.0-20230220064728-6940dc11777f/go.mod h1:V8GFOtdpTgzCJtCVXRqjmdDsY+PIhCCx4JpD0zq8Z7I=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -109,8 +109,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/v2rayA/ahocorasick-domain v0.0.0-20230218160829-122a074c48c8 h1:2Liq3JvM/acVQZ7Gq9U5PpznMzlFRPYMPQxC2yXSi74=
 github.com/v2rayA/ahocorasick-domain v0.0.0-20230218160829-122a074c48c8/go.mod h1:mWch8I826zic/bKaCyE9ZZbWtFgEW0ox3EQ0NGm5DGw=
-github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230201041341-1758ee5161c1 h1:Ke91ZtZItOO8/SK8nhZ1tXfXcUxj4Meq5pET/L9bHII=
-github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230201041341-1758ee5161c1/go.mod h1:JiTWeZybOkBfCqv/fy5jbFhXTxuLlyrI76gRNazz2sU=
+github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230219173344-413f12027632 h1:MJ6+M3MpiVMdiZn3An88ZFNeLcLiN7hTaPsd2bVyduI=
+github.com/v2rayA/dae-config-dist/go/dae_config v0.0.0-20230219173344-413f12027632/go.mod h1:JiTWeZybOkBfCqv/fy5jbFhXTxuLlyrI76gRNazz2sU=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=

--- a/pkg/config_parser/section.go
+++ b/pkg/config_parser/section.go
@@ -178,7 +178,7 @@ func (p *paramAndFunctions) String(compact bool) string {
 
 type RoutingRule struct {
 	AndFunctions []*Function
-	Outbound     string
+	Outbound     Function
 }
 
 func (r *RoutingRule) String(calcN bool) string {
@@ -206,6 +206,6 @@ func (r *RoutingRule) String(calcN bool) string {
 		}
 		builder.WriteString(fmt.Sprintf("%v%v(%v)", symNot, f.Name, paramBuilder.String()))
 	}
-	builder.WriteString(" -> " + r.Outbound)
+	builder.WriteString(" -> " + r.Outbound.String(true))
 	return builder.String()
 }

--- a/pkg/config_parser/walker.go
+++ b/pkg/config_parser/walker.go
@@ -3,6 +3,8 @@
  * Copyright (c) 2022-2023, v2rayA Organization <team@v2raya.org>
  */
 
+// This file should trace https://github.com/v2rayA/dae-config-dist/blob/main/dae_config.g4.
+
 package config_parser
 
 import (
@@ -209,10 +211,18 @@ func (w *Walker) parseRoutingRule(ctx dae_config.IRoutingRuleContext) *RoutingRu
 	andFunctions := w.parseFunctionPrototypeExpression(functionList, nil)
 
 	// Parse outbound.
-	outbound := children[2].(*dae_config.Bare_literalContext).GetText()
+	outboundExpr := children[2].(*dae_config.OutboundExprContext)
+	var outbound *Function
+	if literal := outboundExpr.Bare_literal(); literal != nil {
+		outbound = &Function{Name: literal.GetText()}
+	} else if f := outboundExpr.FunctionPrototype(); f != nil {
+		outbound = w.parseFunctionPrototype(f.(*dae_config.FunctionPrototypeContext), nil)
+	} else {
+		panic("unknown outboundExpr")
+	}
 	return &RoutingRule{
 		AndFunctions: andFunctions,
-		Outbound:     outbound,
+		Outbound:     *outbound,
 	}
 }
 

--- a/routing.md
+++ b/routing.md
@@ -3,12 +3,15 @@
 ## Examples:
 
 ```shell
-# Built-in outbounds: block, direct
+### Built-in outbounds: block, direct, must_direct
+# The difference between "direct" and "must_direct" is that "direct" will intercept and process DNS request (for traffic
+# split use), but "must_direct" will not. "must_direct" is useful when there are traffic loops of DNS requests.
 
+### fallback outbound
 # If no rule matches, traffic will go through the outbound defined by fallback.
 fallback: my_group
 
-# Domain rule
+### Domain rule
 domain(suffix: v2raya.org) -> my_group
 # equals to domain(v2raya.org) -> my_group
 domain(full: dns.google) -> my_group
@@ -17,63 +20,80 @@ domain(regexp: '\.goo.*\.com$') -> my_group
 domain(geosite:category-ads) -> block
 domain(geosite:cn)->direct
 
-# Dest IP rule
+### Dest IP rule
 ip(8.8.8.8) -> direct
 ip(101.97.0.0/16) -> direct
 ip(geoip:private) -> direct
 
-# Source IP rule
+### Source IP rule
 sip(192.168.0.0/24) -> my_group
 sip(192.168.50.0/24) -> direct
 
-# Dest port rule
+### Dest port rule
 port(80) -> direct
 port(10080-30000) -> direct
 
-# Source port rule
+### Source port rule
 sport(38563) -> direct
 sport(10080-30000) -> direct
 
-# Level 4 protocol rule:
+### Level 4 protocol rule:
 l4proto(tcp) -> my_group
 l4proto(udp) -> direct
 
-# IP version rule:
+### IP version rule:
 ipversion(4) -> block
 ipversion(6) -> ipv6_group
 
-# Source MAC rule
+### Source MAC rule
 mac('02:42:ac:11:00:02') -> direct
 
-# Process Name rule (only support local process)
+### Process Name rule (only support localhost process when binding to WAN)
 pname(curl) -> direct
 
-# Multiple domains rule
+### Multiple domains rule
 domain(keyword: google, suffix: www.twitter.com, suffix: v2raya.org) -> my_group
-# Multiple IP rule
+### Multiple IP rule
 ip(geoip:cn, geoip:private) -> direct
 ip(9.9.9.9, 223.5.5.5) -> direct
 sip(192.168.0.6, 192.168.0.10, 192.168.0.15) -> direct
 
-# 'And' rule
+### 'And' rule
 ip(geoip:cn) && port(80) -> direct
 ip(8.8.8.8) && l4proto(tcp) && port(1-1023, 8443) -> my_group
 ip(1.1.1.1) && sip(10.0.0.1, 172.20.0.0/16) -> direct
 
-# 'Not' rule
+### 'Not' rule
 !domain(geosite:google-scholar,
         geosite:category-scholar-!cn,
         geosite:category-scholar-cn
     ) -> my_group
 
-# Little more complex rule
+### Little more complex rule
 domain(geosite:geolocation-!cn) &&
     !domain(geosite:google-scholar,
             geosite:category-scholar-!cn,
             geosite:category-scholar-cn
         ) -> my_group
 
-# Customized DAT file
+### Customized DAT file
 domain(ext:"yourdatfile.dat:yourtag")->direct
 ip(ext:"yourdatfile.dat:yourtag")->direct
+
+### Mark for direct/must_direct outbound
+# Mark is useful when you want to redirect traffic to specific interface (such as wireguard) or other advanced uses.
+# Traffic from LAN will not be forwarded by dae to archive higher performance if lan_nat_direct is off (you can set it
+# off only if you are sure dae is on a bridge device).
+
+# An example of redirecting Disney traffic to wg0 is given here.
+# You need set ip rule and ip table like this:
+# 1. Set all traffic with mark 0x800/0x800 will use route table 1145:
+# >> ip rule add fwmark 0x800/0x800 table 1145
+# >> ip -6 rule add fwmark 0x800/0x800 table 1145
+# 2. Set default route of route table 1145:
+# >> ip route add default dev wg0 scope global table 1145
+# >> ip -6 route add default dev wg0 scope global table 1145
+# Notice that interface wg0, mark 0x800, table 1145 can be set by preferences, but cannot conflict.
+# 3. Set routing rules in dae config file.
+domain(geosite:disney) -> direct(mark: 0x800)
 ```

--- a/routing.md
+++ b/routing.md
@@ -87,7 +87,7 @@ ip(ext:"yourdatfile.dat:yourtag")->direct
 
 # An example of redirecting Disney traffic to wg0 is given here.
 # You need set ip rule and ip table like this:
-# 1. Set all traffic with mark 0x800/0x800 will use route table 1145:
+# 1. Set all traffic with mark 0x800/0x800 to use route table 1145:
 # >> ip rule add fwmark 0x800/0x800 table 1145
 # >> ip -6 rule add fwmark 0x800/0x800 table 1145
 # 2. Set default route of route table 1145:


### PR DESCRIPTION
```shell
### Mark for direct/must_direct outbound
# Mark is useful when you want to redirect traffic to specific interface (such as wireguard) or other advanced uses.
# Traffic from LAN will not be forwarded by dae to archive higher performance if lan_nat_direct is off (you can set it
# off only if you are sure dae is on a bridge device).

# An example of redirecting Disney traffic to wg0 is given here.
# You need set ip rule and ip table like this:
# 1. Set all traffic with mark 0x800/0x800 to use route table 1145:
# >> ip rule add fwmark 0x800/0x800 table 1145
# >> ip -6 rule add fwmark 0x800/0x800 table 1145
# 2. Set default route of route table 1145:
# >> ip route add default dev wg0 scope global table 1145
# >> ip -6 route add default dev wg0 scope global table 1145
# Notice that interface wg0, mark 0x800, table 1145 can be set by preferences, but cannot conflict.
# 3. Set routing rules in dae config file.
domain(geosite:disney) -> direct(mark: 0x800)
```